### PR TITLE
Update workflow image to Ubuntu 24.04

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version:


### PR DESCRIPTION
I started getting e-mail notifications about failed scheduled jobs due to a deprecated Ubuntu image :sweat_smile: Not sure who can still merge to this repository, maybe @fphammerle?